### PR TITLE
Refactor database communcation.

### DIFF
--- a/NuffBot/Commands/AddAliasesCommand.cs
+++ b/NuffBot/Commands/AddAliasesCommand.cs
@@ -38,11 +38,11 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> dbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((dbCommand) => dbCommand.Name == name);
+      DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (dbObject.Entity == null)
+      if (!dbObject.Exists())
       {
-        bot.SendMessage($"Command with name '{name}' doesn't exist!", context);
+        bot.SendMessage($"Command or alias with name '{name}' doesn't exist!", context);
 
         return;
       }

--- a/NuffBot/Commands/AddTimerCommand.cs
+++ b/NuffBot/Commands/AddTimerCommand.cs
@@ -60,16 +60,16 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> dbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Name == name);
+      DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (dbObject.Entity == null)
+      if (!dbObject.Exists())
       {
-        bot.SendMessage($"Command with name '{name}' doesn't exist!", context);
+        bot.SendMessage($"Command or alias with name '{name}' doesn't exist!", context);
 
         return;
       }
 
-      Timer timer = new Timer(dbObject.Entity.Id, timeTrigger, messageTrigger);
+      TimerModel timer = new TimerModel(dbObject.Entity.Id, timeTrigger, messageTrigger);
 
       if (!await timer.SaveToDatabase(SqliteDatabase.Instance))
       {

--- a/NuffBot/Commands/CommandModel.cs
+++ b/NuffBot/Commands/CommandModel.cs
@@ -4,14 +4,14 @@ using ServiceStack.DataAnnotations;
 
 namespace NuffBot.Commands
 {
-  public class DatabaseCommand : IDatabaseObject
+  public class CommandModel : IDatabaseObject
   {
     [AutoIncrement] public ulong Id { get; set; }
     [Unique] public string Name { get; set; }
     public List<string> Aliases { get; set; }
     public string Response { get; set; }
 
-    public DatabaseCommand(string name, List<string> aliases, string response)
+    public CommandModel(string name, List<string> aliases, string response)
     {
       Name = name;
       Aliases = aliases;

--- a/NuffBot/Commands/CommandProcessor.cs
+++ b/NuffBot/Commands/CommandProcessor.cs
@@ -44,21 +44,12 @@ namespace NuffBot.Commands
 
       if (commandToExecute == null)
       {
-        DatabaseObject<DatabaseCommand> dbCommand = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>(c => c.Name == name);
+        DatabaseObject<CommandModel> dbCommand = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-        if (dbCommand.Entity == null)
+        if (dbCommand.Exists())
         {
-          List<DatabaseObject<DatabaseCommand>> allCommands = await SqliteDatabase.Instance.ReadAllAsync<DatabaseCommand>();
-
-          dbCommand = allCommands.FirstOrDefault(db => db.Entity.Aliases.Contains(name));
-
-          if (dbCommand == null)
-          {
-            return;
-          }
+          bot.SendMessage(dbCommand.Entity.Response, context);
         }
-
-        bot.SendMessage(dbCommand.Entity.Response, context);
 
         return;
       }

--- a/NuffBot/Commands/DeleteAliasesCommand.cs
+++ b/NuffBot/Commands/DeleteAliasesCommand.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace NuffBot.Commands
@@ -37,14 +36,12 @@ namespace NuffBot.Commands
         return;
       }
 
-      List<DatabaseObject<DatabaseCommand>> allCommands = await SqliteDatabase.Instance.ReadAllAsync<DatabaseCommand>();
-
       int count = 0;
-      
+
       foreach (string alias in aliases)
       {
-        DatabaseObject<DatabaseCommand> dbObject = allCommands.FirstOrDefault(db => db.Entity.Aliases.Contains(alias));
-        
+        DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByAlias(alias);
+
         if (dbObject == null)
         {
           bot.SendMessage($"Command with alias '{alias}' doesn't exist!", context);
@@ -62,7 +59,11 @@ namespace NuffBot.Commands
 
       if (count == aliases.Length)
       {
-        bot.SendMessage("Alias(es) removed successfully!", context);
+        bot.SendMessage($"{count} alias(es) removed successfully!", context);
+      }
+      else
+      {
+        bot.SendMessage($"Failed to remove {aliases.Length - count} alias(es)!", context);
       }
     }
   }

--- a/NuffBot/Commands/DeleteCommand.cs
+++ b/NuffBot/Commands/DeleteCommand.cs
@@ -20,9 +20,30 @@ namespace NuffBot.Commands
         return;
       }
 
-      string name = parser.ParseWord();
+      string name;
 
-      if (!await SqliteDatabase.Instance.DeleteAsync<DatabaseCommand>((c) => c.Name == name))
+      try
+      {
+        name = parser.ParseWord();
+      }
+      catch (CommandParseError error)
+      {
+        bot.SendMessage(error.Message, context);
+        bot.SendMessage(Usage, context);
+
+        return;
+      }
+
+      DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
+      
+      if (!dbObject.Exists())
+      {
+        bot.SendMessage($"Command with name or alias '{name}' doesn't exist!", context);
+
+        return;
+      }
+      
+      if (!await dbObject.DeleteFromDatabase(SqliteDatabase.Instance))
       {
         bot.SendMessage("Failed to delete command from the database.", context);
       }

--- a/NuffBot/Commands/DeleteTimerCommand.cs
+++ b/NuffBot/Commands/DeleteTimerCommand.cs
@@ -35,18 +35,18 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> commandDbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Name == name);
+      DatabaseObject<CommandModel> commandDbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (commandDbObject.Entity == null)
+      if (!commandDbObject.Exists())
       {
         bot.SendMessage($"Timer '{name}' doesn't exist because there's no such command!", context);
 
         return;
       }
       
-      DatabaseObject<Timer> timerDbObject = await SqliteDatabase.Instance.ReadSingleAsync<Timer>((t) => t.CommandId == commandDbObject.Entity.Id);
+      DatabaseObject<TimerModel> timerDbObject = await DatabaseHelper.GetTimerByCommand(commandDbObject.Entity);
 
-      if (timerDbObject.Entity == null)
+      if (!timerDbObject.Exists())
       {
         bot.SendMessage($"Timer with name '{name}' doesn't exist!", context);
         

--- a/NuffBot/Commands/ShowAliasesCommand.cs
+++ b/NuffBot/Commands/ShowAliasesCommand.cs
@@ -36,9 +36,9 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> dbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Name == name);
+      DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (dbObject.Entity == null)
+      if (!dbObject.Exists())
       {
         bot.SendMessage($"Command with name '{name}' doesn't exist!", context);
 

--- a/NuffBot/Commands/ShowCommand.cs
+++ b/NuffBot/Commands/ShowCommand.cs
@@ -20,11 +20,23 @@ namespace NuffBot.Commands
         return;
       }
 
-      string name = parser.ParseWord();
+      string name;
 
-      DatabaseObject<DatabaseCommand> dbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Name == name);
+      try
+      {
+        name = parser.ParseWord();
+      }
+      catch (CommandParseError error)
+      {
+        bot.SendMessage(error.Message, context);
+        bot.SendMessage(Usage, context);
 
-      if (dbObject.Entity == null)
+        return;
+      }
+
+      DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
+
+      if (!dbObject.Exists())
       {
         bot.SendMessage($"Command with name '{name}' doesn't exist!", context);
 

--- a/NuffBot/Commands/ShowTimer.cs
+++ b/NuffBot/Commands/ShowTimer.cs
@@ -8,7 +8,7 @@ namespace NuffBot.Commands
     public override string Name => "showtimer";
     public override UserLevel UserLevel => UserLevel.Viewer;
 
-    private const string Usage = "Usage: !showcmd <name> - Shows internal representation of a timer.";
+    private const string Usage = "Usage: !showtimer <name> - Shows internal representation of a timer.";
 
     protected override async Task Execute<T>(ChatMessage<T> message, CommandContext context, Bot bot)
     {
@@ -35,18 +35,18 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> commandDbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Name == name);
+      DatabaseObject<CommandModel> commandDbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (commandDbObject.Entity == null)
+      if (!commandDbObject.Exists())
       {
         bot.SendMessage($"Timer '{name}' doesn't exist because there's no such command!", context);
 
         return;
       }
 
-      DatabaseObject<Timer> timerDbObject = await SqliteDatabase.Instance.ReadSingleAsync<Timer>((t) => t.CommandId == commandDbObject.Entity.Id);
+      DatabaseObject<TimerModel> timerDbObject = await DatabaseHelper.GetTimerByCommand(commandDbObject.Entity);
 
-      if (timerDbObject.Entity == null)
+      if (!timerDbObject.Exists())
       {
         bot.SendMessage($"Timer with name '{name}' doesn't exist!", context);
 

--- a/NuffBot/Commands/UpdateCommand.cs
+++ b/NuffBot/Commands/UpdateCommand.cs
@@ -39,9 +39,9 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> dbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((dbCommand) => dbCommand.Name == name);
+      DatabaseObject<CommandModel> dbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (dbObject.Entity == null)
+      if (!dbObject.Exists())
       {
         bot.SendMessage($"Command with name '{name}' doesn't exist!", context);
 

--- a/NuffBot/Commands/UpdateTimerCommand.cs
+++ b/NuffBot/Commands/UpdateTimerCommand.cs
@@ -60,18 +60,18 @@ namespace NuffBot.Commands
         return;
       }
 
-      DatabaseObject<DatabaseCommand> commandDbObject = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Name == name);
+      DatabaseObject<CommandModel> commandDbObject = await DatabaseHelper.GetCommandByNameOrAlias(name);
 
-      if (commandDbObject.Entity == null)
+      if (!commandDbObject.Exists())
       {
         bot.SendMessage($"Timer '{name}' doesn't exist because there's no such command!", context);
 
         return;
       }
 
-      DatabaseObject<Timer> timerDbObject = await SqliteDatabase.Instance.ReadSingleAsync<Timer>((t) => t.CommandId == commandDbObject.Entity.Id);
+      DatabaseObject<TimerModel> timerDbObject = await DatabaseHelper.GetTimerByCommand(commandDbObject.Entity);
 
-      if (timerDbObject.Entity == null)
+      if (!timerDbObject.Exists())
       {
         bot.SendMessage($"Timer with name '{name}' doesn't exist!", context);
 

--- a/NuffBot/Core/TimerManager.cs
+++ b/NuffBot/Core/TimerManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Timers;
 using NuffBot.Commands;
 using NuffBot.Discord;
 
@@ -28,10 +29,10 @@ namespace NuffBot.Core
       }
     }
 
-    private Timer currentTimer;
+    private TimerModel currentTimer;
     private int messageCount;
     private readonly Bot bot;
-    private System.Timers.Timer triggerTimer;
+    private Timer triggerTimer;
 
     public TimerManager(Bot bot)
     {
@@ -49,7 +50,7 @@ namespace NuffBot.Core
 
       triggerTimer?.Stop();
 
-      List<DatabaseObject<Timer>> timers = await SqliteDatabase.Instance.ReadAllAsync<Timer>();
+      List<DatabaseObject<TimerModel>> timers = await DatabaseHelper.GetAllTimers();
 
       // Make sure to not select the same timer twice in a row (if more than 1 is present).
       if (timers.Count > 1)
@@ -71,7 +72,7 @@ namespace NuffBot.Core
           return;
         }
 
-        triggerTimer = new System.Timers.Timer(currentTimer.TimeTrigger * 1000);
+        triggerTimer = new Timer(currentTimer.TimeTrigger * 1000);
 
         triggerTimer.Start();
 
@@ -79,9 +80,9 @@ namespace NuffBot.Core
       }
     }
 
-    private async void ExecuteTimer(Timer timer)
+    private async void ExecuteTimer(TimerModel timer)
     {
-      DatabaseObject<DatabaseCommand> command = await SqliteDatabase.Instance.ReadSingleAsync<DatabaseCommand>((c) => c.Id == timer.CommandId);
+      DatabaseObject<CommandModel> command = await DatabaseHelper.GetCommandById(timer.CommandId);
 
       bot.SendMessage(command.Entity.Response, new CommandContext(DiscordBot.CurrentGuild, TwitchBot.CurrentChannel));
 

--- a/NuffBot/Core/TimerModel.cs
+++ b/NuffBot/Core/TimerModel.cs
@@ -4,16 +4,16 @@ using ServiceStack.DataAnnotations;
 
 namespace NuffBot.Core
 {
-  public class Timer : IDatabaseObject
+  public class TimerModel : IDatabaseObject
   {
     [AutoIncrement] public ulong Id { get; set; }
 
-    [ForeignKey(typeof(DatabaseCommand), OnDelete = "CASCADE")]
+    [ForeignKey(typeof(CommandModel), OnDelete = "CASCADE")]
     public ulong CommandId { get; set; }
     public int TimeTrigger { get; set; }
     public int MessageTrigger { get; set; }
 
-    public Timer(ulong commandId, int timeTrigger, int messageTrigger)
+    public TimerModel(ulong commandId, int timeTrigger, int messageTrigger)
     {
       CommandId = commandId;
       TimeTrigger = timeTrigger;

--- a/NuffBot/Database/DatabaseHelper.cs
+++ b/NuffBot/Database/DatabaseHelper.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuffBot.Commands;
+using NuffBot.Core;
+
+namespace NuffBot
+{
+  public static class DatabaseHelper
+  {
+    public static async Task<DatabaseObject<CommandModel>> GetCommandByNameOrAlias(string name)
+    {
+      DatabaseObject<CommandModel> dbCommand = await SqliteDatabase.Instance.ReadSingleAsync<CommandModel>(c => c.Name == name);
+
+      if (!dbCommand.Exists())
+      {
+        dbCommand = await GetCommandByAlias(name);
+      }
+
+      return dbCommand;
+    }
+
+    public static async Task<List<DatabaseObject<CommandModel>>> GetAllCommands()
+    {
+      return await SqliteDatabase.Instance.ReadAllAsync<CommandModel>();
+    }
+
+    public static async Task<DatabaseObject<CommandModel>> GetCommandByAlias(string alias)
+    {
+      List<DatabaseObject<CommandModel>> allCommands = await GetAllCommands();
+
+      return new DatabaseObject<CommandModel>(allCommands.Select((c) => c.Entity).FirstOrDefault(c => c.Aliases.Contains(alias)));
+    }
+
+    public static async Task<DatabaseObject<TimerModel>> GetTimerByCommand(CommandModel command)
+    {
+      return await SqliteDatabase.Instance.ReadSingleAsync<TimerModel>((t) => t.CommandId == command.Id);
+    }
+
+    public static async Task<List<DatabaseObject<TimerModel>>> GetAllTimers()
+    {
+      return await SqliteDatabase.Instance.ReadAllAsync<TimerModel>();
+    }
+
+    public static async Task<DatabaseObject<CommandModel>> GetCommandById(ulong id)
+    {
+      return await SqliteDatabase.Instance.ReadSingleAsync<CommandModel>((c) => c.Id == id);
+    }
+  }
+}

--- a/NuffBot/Database/DatabaseObject.cs
+++ b/NuffBot/Database/DatabaseObject.cs
@@ -21,5 +21,10 @@ namespace NuffBot
     {
       return await database.DeleteEntityAsync(Entity);
     }
+
+    public bool Exists()
+    {
+      return Entity != null;
+    }
   }
 }


### PR DESCRIPTION
* Rename database models to `*Model`.
* Create DatabaseHelper (closes #39). 
* Support aliases in !showcmd and other places through DatabaseHelper (closes #33).
* Implement DatabaseObject::Exists.
* Validate aliases only in !addcmd.
* Check whether command exists in !delcmd (closes #24).